### PR TITLE
Update YDevLib to 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>com.github.Ynfuien</groupId>
             <artifactId>YDevLib</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.6</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
The artifacts for YDevLib 1.0.2 is not available on Jitpack, which was causing the build to fail. The developer API is currently not accessible due to builds failing on Jitpack, so this PR should fix that issue.